### PR TITLE
Resolve log version compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"prototypes": "^2.3.3",
 		"testing": "^1.1.1",
-		"log": "*"
+		"log": "~1.4.0"
 	},
 	"keywords": [
 		"profiler",


### PR DESCRIPTION
From major 2.0 and onwards fails with error:

`TypeError: log.info is not a function
    at Profiler.show (/home/ljdm/workspace/Github/alexfernandez/instrumented-pareto-simulator/node_modules/microprofiler/lib/profiler.js:129:6)
    at Profiler.measure (/home/ljdm/workspace/Github/alexfernandez/instrumented-pareto-simulator/node_modules/microprofiler/lib/profiler.js:122:8)`